### PR TITLE
feat: add parsing of metadata to webhook event

### DIFF
--- a/btcpay_test.go
+++ b/btcpay_test.go
@@ -49,8 +49,11 @@ func TestInvoice(t *testing.T) {
 		"type": "InvoiceCreated",
 		"timestamp": 1610000000,
 		"storeId": "%s",
-		"invoiceId": "%s"
-	}`, store.ID, got.ID))
+		"invoiceId": "%s",
+		"metadata": {
+			"orderId": "%s"
+		}
+	}`, store.ID, got.ID, got.InvoiceMetadata.OrderID))
 
 	var webhookRequest = &http.Request{
 		Body:   io.NopCloser(bytes.NewReader(body)),
@@ -66,6 +69,10 @@ func TestInvoice(t *testing.T) {
 	}
 
 	if event.StoreID != store.ID || event.Type != EventInvoiceCreated || event.InvoiceID != got.ID {
+		t.Fail()
+	}
+
+	if event.InvoiceMetadata.OrderID != got.InvoiceMetadata.OrderID {
 		t.Fail()
 	}
 }

--- a/event.go
+++ b/event.go
@@ -13,17 +13,18 @@ const (
 	EventInvoiceSettled         EventType = "InvoiceSettled"
 )
 
-// An InvoiceEvent is sent by a webhook. You can use GetInvoice to obtain the
-// full invoice, which includes your custom OrderID.
+// An InvoiceEvent is sent by a webhook.
+// You can find your custom OrderID in InvoiceMetadata or use GetInvoice to obtain the full invoice.
 type InvoiceEvent struct {
-	DeliveryID         string    `json:"deliveryId"`
-	InvoiceID          string    `json:"invoiceId"`
-	IsRedelivery       bool      `json:"isRedelivery"`
-	OriginalDeliveryID string    `json:"originalDeliveryId"`
-	StoreID            string    `json:"storeId"`
-	Timestamp          int64     `json:"timestamp"`
-	Type               EventType `json:"type"`
-	WebhookID          string    `json:"webhookId"`
+	DeliveryID         string          `json:"deliveryId"`
+	InvoiceID          string          `json:"invoiceId"`
+	IsRedelivery       bool            `json:"isRedelivery"`
+	OriginalDeliveryID string          `json:"originalDeliveryId"`
+	StoreID            string          `json:"storeId"`
+	Timestamp          int64           `json:"timestamp"`
+	Type               EventType       `json:"type"`
+	WebhookID          string          `json:"webhookId"`
+	InvoiceMetadata    InvoiceMetadata `json:"metadata"`
 
 	// InvoiceInvalid and InvoiceSettled only
 	ManuallyMarked bool `json:"manuallyMarked"`


### PR DESCRIPTION
Hi,
according to the [docs](https://docs.btcpayserver.org/API/Greenfield/v1/#operation/Webhook_InvoiceCreated) and my experiments current btcpay servers sent the metadata of the invoice for all webhook events.  
This PR adds `InvoiceMetadata` to `InvoiceEvent`. Which allows direct access to the `OrderId` during webhook processing, without the need to use `GetInvoice`.